### PR TITLE
Add input mocking examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,16 +19,17 @@ members = ["./", "tools/ci"]
 
 [features]
 default = []
+ui = ["bevy_ui", "bevy_window"]
 
 [dependencies]
 bevy_app = {version = "0.7", default-features = false}
-bevy_core = {version = "0.7", default-features = false}
 bevy_transform = {version = "0.7", default-features = false}
 bevy_ecs = {version = "0.7", default-features = false}
 bevy_input = {version = "0.7", default-features = false, features = ["serialize"]}
 bevy_math = {version = "0.7", default-features = false}
 bevy_utils = {version = "0.7", default-features = false}
-bevy_window = {version = "0.7", default-features = false}
+bevy_ui = {version = "0.7", default-features = false, optional = true}
+bevy_window = {version = "0.7", default-features = false, optional = true}
 
 petitset = {version = "0.2", features = ["serde_compat"]}
 derive_more = {version = "0.99", default-features = false, features = ["display", "error"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = ["./", "tools/ci"]
 
 [features]
 default = []
-ui = ["bevy_ui", "bevy_window"]
+ui = ["bevy_ui"]
 
 [dependencies]
 bevy_app = {version = "0.7", default-features = false}
@@ -29,7 +29,7 @@ bevy_input = {version = "0.7", default-features = false, features = ["serialize"
 bevy_math = {version = "0.7", default-features = false}
 bevy_utils = {version = "0.7", default-features = false}
 bevy_ui = {version = "0.7", default-features = false, optional = true}
-bevy_window = {version = "0.7", default-features = false, optional = true}
+bevy_window = {version = "0.7", default-features = false}
 
 petitset = {version = "0.2", features = ["serde_compat"]}
 derive_more = {version = "0.99", default-features = false, features = ["display", "error"]}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A input recording, mocking and playback library for the [Bevy] game engine in Rust.
 
+This crate is designed to work smoothly with [`leafwing-input-manager`](https://crates.io/crates/leafwing-input-manager), a simple but expressive tool to map user inputs to in-game actions.
+
 ## Features
 
 - Powerful and easy-to-use input mocking API for integration testing your Bevy applications

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,3 +5,8 @@
 ### Enhancements
 
 - shamelessly stole input mocking functionality from `leafwing_input_playback`
+- added the `RegisterGamepads` trait for easy mocking of specific gamepad inputs
+
+### Docs
+
+- added basic examples of how to perform input mocking for buttonlike inputs

--- a/examples/basic_input_mocking.rs
+++ b/examples/basic_input_mocking.rs
@@ -1,0 +1,71 @@
+//! Demonstrates how to use input mocking to send fake inputs.
+//!
+//! This is particularly valuable when testing Bevy apps, as mocked inputs can be performed reliably and automatically.
+
+use bevy::prelude::*;
+use bevy_input::InputPlugin;
+// Check out this trait to see the convenient methods on `App`, `World` and `MutableInputStreams`!
+use leafwing_input_playback::MockInput;
+
+// Usually, this would be an integration test,
+// in the root level `tests` directory
+// annotated with the #[test] macro
+fn main() {
+    // Create and store your new App
+    let mut app = App::new();
+
+    // Then, configure it
+    // This is often useful to save with helper functions so you can reuse it between tests
+    app.add_plugins(MinimalPlugins)
+        .add_plugin(InputPlugin)
+        .add_system(toggle_resource_on_space)
+        .insert_resource(Toggle::Off);
+
+    // Type inference makes writing tests quick and easy
+    assert_eq!(Toggle::Off, *app.world.resource());
+
+    // And we can quickly debug state too
+    dbg!(app.world.resource::<Toggle>());
+
+    // Update your app one tick at a time to get full control
+    app.update();
+
+    // No trickery here
+    assert_eq!(Toggle::Off, *app.world.resource());
+
+    // Sending inputs is a breeze
+    app.send_input(KeyCode::Space);
+
+    // Oops, forgot to update the app...
+    assert_eq!(Toggle::Off, *app.world.resource());
+
+    // There we go
+    app.update();
+    assert_eq!(Toggle::On, *app.world.resource());
+
+    // Inputs stay pressed until released,
+    // so updating our app causes the toggle to be turned back off
+    app.update();
+    assert_eq!(Toggle::Off, *app.world.resource());
+
+    // We can release them one at a time
+    app.release_input(KeyCode::Space);
+
+    // Or all at once
+    app.reset_inputs();
+}
+
+#[derive(PartialEq, Debug)]
+enum Toggle {
+    Off,
+    On,
+}
+
+fn toggle_resource_on_space(keyboard_input: Res<Input<KeyCode>>, mut toggle: ResMut<Toggle>) {
+    if keyboard_input.pressed(KeyCode::Space) {
+        *toggle = match *toggle {
+            Toggle::Off => Toggle::On,
+            Toggle::On => Toggle::Off,
+        }
+    }
+}

--- a/examples/gamepad_input_mocking.rs
+++ b/examples/gamepad_input_mocking.rs
@@ -4,6 +4,7 @@
 //! as gamepad input is associated with a specific registered gamepad.
 
 use bevy::prelude::*;
+use bevy::utils::HashMap;
 use bevy_input::InputPlugin;
 use leafwing_input_playback::{MockInput, RegisterGamepads};
 
@@ -14,10 +15,12 @@ fn main() {
     // This is often useful to save with helper functions so you can reuse it between tests
     app.add_plugins(MinimalPlugins)
         .add_plugin(InputPlugin)
-        .add_system(jump::<Player1>)
-        .add_system(jump::<Player2>)
         .add_system(pause_game)
-        .insert_resource(Toggle::Off);
+        .add_system(jump)
+        .insert_resource(GamepadPlayerMap(HashMap::from_iter([
+            (Gamepad(0), 0),
+            (Gamepad(1), 1),
+        ])));
 
     // Gamepads are registered in the `Gamepads` resource
     let gamepads = app.world.resource::<Gamepads>();
@@ -26,28 +29,45 @@ fn main() {
     // We need to first simulate a connection
     // The GamepadRegistration trait provides convenient methods on `App` and `World` for this
     app.register_gamepad(Gamepad(0));
+    app.register_gamepad(Gamepad(1));
+
+    // The Gamepads resource lists all currently registered gamepads
     let gamepads = app.world.resource::<Gamepads>();
-    assert_eq!(gamepads.iter().count(), 1);
+    assert_eq!(gamepads.iter().count(), 2);
 
     // Gamepad input is specific to a controller
+    app.send_input_to_gamepad(GamepadButtonType::South, Some(Gamepad(0)));
+    app.send_input_to_gamepad(GamepadButtonType::South, Some(Gamepad(1)));
+    app.send_input_to_gamepad(GamepadButtonType::South, Some(Gamepad(0)));
 
     // But some systems may accept input from any controller
+    app.send_input(GamepadButtonType::Start);
+
+    // When all gamepads are deregistered, gamepad events will not be picked up
+    app.deregister_gamepad(Gamepad(0));
+    app.deregister_gamepad(Gamepad(1));
+    app.send_input(GamepadButtonType::Start);
 }
 
-#[derive(PartialEq, Debug)]
-enum Toggle {
-    Off,
-    On,
-}
-
-// Systems that read gamepad input can work on either inputs sent by any gamepad
-fn pause_game() {
-    if gamepad_input.pressed(KeyCode::Space) {
-        *toggle = match *toggle {
-            Toggle::Off => Toggle::On,
-            Toggle::On => Toggle::Off,
+// Systems that read gamepad input can work on inputs sent by any gamepad
+fn pause_game(gamepad_input: Res<Input<GamepadButton>>, gamepads: Res<Gamepads>) {
+    for &gamepad in gamepads.iter() {
+        let start_button = GamepadButton(gamepad, GamepadButtonType::Start);
+        if gamepad_input.pressed(start_button) {
+            println!("Game paused or unpaused.");
         }
     }
 }
 
+#[derive(Deref, DerefMut)]
+struct GamepadPlayerMap(HashMap<Gamepad, u8>);
+
 // Or systems can be particular about which gamepad they accept inputs from
+fn jump(gamepad_input: Res<Input<GamepadButton>>, gamepad_player_map: Res<GamepadPlayerMap>) {
+    for (&gamepad, player) in gamepad_player_map.iter() {
+        let a_button = GamepadButton(gamepad, GamepadButtonType::South);
+        if gamepad_input.pressed(a_button) {
+            println!("Player {player} jumped!");
+        }
+    }
+}

--- a/examples/gamepad_input_mocking.rs
+++ b/examples/gamepad_input_mocking.rs
@@ -5,7 +5,7 @@
 
 use bevy::prelude::*;
 use bevy_input::InputPlugin;
-use leafwing_input_playback::MockInput;
+use leafwing_input_playback::{MockInput, RegisterGamepads};
 
 fn main() {
     let mut app = App::new();
@@ -14,12 +14,20 @@ fn main() {
     // This is often useful to save with helper functions so you can reuse it between tests
     app.add_plugins(MinimalPlugins)
         .add_plugin(InputPlugin)
-        .add_system(toggle_resource_on_start_button)
+        .add_system(jump::<Player1>)
+        .add_system(jump::<Player2>)
+        .add_system(pause_game)
         .insert_resource(Toggle::Off);
 
     // Gamepads are registered in the `Gamepads` resource
+    let gamepads = app.world.resource::<Gamepads>();
+    assert_eq!(gamepads.iter().count(), 0);
 
     // We need to first simulate a connection
+    // The GamepadRegistration trait provides convenient methods on `App` and `World` for this
+    app.register_gamepad(Gamepad(0));
+    let gamepads = app.world.resource::<Gamepads>();
+    assert_eq!(gamepads.iter().count(), 1);
 
     // Gamepad input is specific to a controller
 
@@ -33,8 +41,13 @@ enum Toggle {
 }
 
 // Systems that read gamepad input can work on either inputs sent by any gamepad
-fn toggle_resource_on_start_button() {
-    todo!()
+fn pause_game() {
+    if gamepad_input.pressed(KeyCode::Space) {
+        *toggle = match *toggle {
+            Toggle::Off => Toggle::On,
+            Toggle::On => Toggle::Off,
+        }
+    }
 }
 
 // Or systems can be particular about which gamepad they accept inputs from

--- a/examples/gamepad_input_mocking.rs
+++ b/examples/gamepad_input_mocking.rs
@@ -1,0 +1,40 @@
+//! Demonstrates how to mock gamepad inputs
+//!
+//! This is somewhat more involved than mocking mouse and keyboard input,
+//! as gamepad input is associated with a specific registered gamepad.
+
+use bevy::prelude::*;
+use bevy_input::InputPlugin;
+use leafwing_input_playback::MockInput;
+
+fn main() {
+    let mut app = App::new();
+
+    // Then, configure it
+    // This is often useful to save with helper functions so you can reuse it between tests
+    app.add_plugins(MinimalPlugins)
+        .add_plugin(InputPlugin)
+        .add_system(toggle_resource_on_start_button)
+        .insert_resource(Toggle::Off);
+
+    // Gamepads are registered in the `Gamepads` resource
+
+    // We need to first simulate a connection
+
+    // Gamepad input is specific to a controller
+
+    // But some systems may accept input from any controller
+}
+
+#[derive(PartialEq, Debug)]
+enum Toggle {
+    Off,
+    On,
+}
+
+// Systems that read gamepad input can work on either inputs sent by any gamepad
+fn toggle_resource_on_start_button() {
+    todo!()
+}
+
+// Or systems can be particular about which gamepad they accept inputs from

--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -483,10 +483,13 @@ mod test {
     #[test]
     fn gamepad_registration() {
         use crate::input_mocking::RegisterGamepads;
+        use bevy_ecs::event::Events;
         use bevy_ecs::prelude::*;
         use bevy_input::prelude::*;
 
         let mut world = World::new();
+        world.init_resource::<Gamepads>();
+        world.init_resource::<Events<GamepadEvent>>();
         let gamepads = world.resource::<Gamepads>();
         assert_eq!(gamepads.iter().count(), 0);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod display_impl;
 pub mod errors;
 mod input_mocking;
 // Re-export this at the root level for convenience
-pub use input_mocking::MockInput;
+pub use input_mocking::{MockInput, RegisterGamepads};
 pub mod axislike;
 pub mod buttonlike;
 pub mod orientation;


### PR DESCRIPTION
This PR adds documentation, assorted cleanup, and the `RegisterGamepads` convenience trait.