### PR TITLE
Capture and playback `AppExit` events

### DIFF
--- a/data/app_exit.ron
+++ b/data/app_exit.ron
@@ -1,0 +1,13 @@
+(
+    events: [
+        (
+            frame: (71),
+            time_since_startup: (
+                secs: 1,
+                nanos: 592977800,
+            ),
+            input_event: AppExit,
+        ),
+    ],
+    cursor: 0,
+)

--- a/examples/useless_machine.rs
+++ b/examples/useless_machine.rs
@@ -1,0 +1,15 @@
+//! [`AppExit`] events are played back and captured too!
+//!
+//! This example loads the file, which only contains an `AppExit`,
+//! and then immediately quits itself as soon as it is encountered.
+use bevy::prelude::*;
+use leafwing_input_playback::input_playback::InputPlaybackPlugin;
+use leafwing_input_playback::serde::PlaybackFilePath;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(InputPlaybackPlugin)
+        .insert_resource(PlaybackFilePath::new("./data/app_exit.ron"))
+        .run();
+}

--- a/src/input_capture.rs
+++ b/src/input_capture.rs
@@ -91,6 +91,7 @@ pub fn capture_input(
     mut mouse_wheel_events: EventReader<MouseWheel>,
     mut cursor_moved_events: EventReader<CursorMoved>,
     mut keyboard_events: EventReader<KeyboardInput>,
+    mut app_exit_events: EventReader<AppExit>,
     mut timestamped_input: ResMut<TimestampedInputs>,
     input_modes_captured: Res<InputModesCaptured>,
     frame_count: Res<FrameCount>,
@@ -128,6 +129,8 @@ pub fn capture_input(
     if input_modes_captured.keyboard {
         timestamped_input.send_multiple(frame, time_since_startup, keyboard_events.iter().cloned());
     }
+
+    timestamped_input.send_multiple(frame, time_since_startup, app_exit_events.iter().cloned())
 }
 
 /// Serializes captured input to the path given in the [`PlaybackFilePath`] resource.

--- a/src/input_playback.rs
+++ b/src/input_playback.rs
@@ -98,6 +98,7 @@ pub struct InputWriters<'w, 's> {
     pub mouse_wheel: EventWriter<'w, 's, MouseWheel>,
     pub cursor_moved: EventWriter<'w, 's, CursorMoved>,
     pub windows: ResMut<'w, Windows>,
+    pub app_exit: EventWriter<'w, 's, AppExit>,
 }
 
 // `TimestampedInputs` is an iterator, so we need mutable access to be able to track which events we've seen
@@ -201,6 +202,7 @@ fn send_playback_events(
 
                 input_writers.cursor_moved.send(e)
             }
+            AppExit => input_writers.app_exit.send_default(),
         };
     }
 }

--- a/src/input_playback.rs
+++ b/src/input_playback.rs
@@ -2,7 +2,7 @@
 //!
 //! These are played back by emulating assorted Bevy input events.
 
-use bevy::app::{App, CoreStage, Plugin};
+use bevy::app::{App, AppExit, CoreStage, Plugin};
 use bevy::ecs::{prelude::*, system::SystemParam};
 use bevy::input::{
     keyboard::KeyboardInput,

--- a/src/timestamped_input.rs
+++ b/src/timestamped_input.rs
@@ -2,6 +2,7 @@
 //! These are first unified into a [`InputEvent`] enum, then timestamped to create a [`TimestampedInputEvent`].
 //! Those timestamped events are finally stored inside of a [`TimestampedInputs`] resource, which should be used for input capture and playback.
 
+use bevy::app::AppExit;
 use bevy::input::keyboard::KeyboardInput;
 use bevy::input::mouse::{MouseButtonInput, MouseWheel};
 use bevy::utils::Duration;

--- a/src/timestamped_input.rs
+++ b/src/timestamped_input.rs
@@ -14,8 +14,7 @@ use crate::frame_counting::FrameCount;
 /// A timestamped device-agnostic user-input event
 ///
 /// These are re-emitted as events, and commonly serialized to disk
-// BLOCKED: should be PartialEq, but https://github.com/bevyengine/bevy/issues/6024
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TimestampedInputEvent {
     /// The number of frames that have elapsed since the app began
     pub frame: FrameCount,
@@ -28,8 +27,7 @@ pub struct TimestampedInputEvent {
 /// A resource that stores the complete event-like list of [`TimestampedInputs`]
 ///
 /// Read and write to this struct when performing input capture and playback
-// BLOCKED: should be PartialEq, but https://github.com/bevyengine/bevy/issues/6024
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TimestampedInputs {
     /// The underlying [`TimestampedInputEvent`] data
     ///
@@ -355,7 +353,7 @@ pub enum SortingStrategy {
 /// Collects input-relevant events for use in [`TimestampedInputs`]
 // BLOCKED: this should be PartialEq, but we're blocked on https://github.com/bevyengine/bevy/issues/6024
 #[allow(missing_docs)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum InputEvent {
     Keyboard(KeyboardInput),
     MouseButton(MouseButtonInput),

--- a/src/timestamped_input.rs
+++ b/src/timestamped_input.rs
@@ -360,6 +360,7 @@ pub enum InputEvent {
     MouseButton(MouseButtonInput),
     MouseWheel(MouseWheel),
     CursorMoved(CursorMoved),
+    AppExit,
 }
 
 impl From<KeyboardInput> for InputEvent {
@@ -383,6 +384,12 @@ impl From<MouseWheel> for InputEvent {
 impl From<CursorMoved> for InputEvent {
     fn from(event: CursorMoved) -> Self {
         InputEvent::CursorMoved(event)
+    }
+}
+
+impl From<AppExit> for InputEvent {
+    fn from(_event: AppExit) -> Self {
+        InputEvent::AppExit
     }
 }
 


### PR DESCRIPTION
Fixes #17. We can just capture and play these back, which is way nicer than quitting automatically when we run out input events to play back.