### PR TITLE
Upgrade to Bevy 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ members = ["./", "tools/ci"]
 default = []
 
 [dependencies]
-bevy = {version ="0.10", default_features = false, features = ["serialize"]}
+bevy = {version = "0.12", default_features = false, features = ["serialize"]}
 serde = {version = "1.0", features = ["derive"]}
 ron = "0.8"
 
 [dev-dependencies]
-bevy = {version ="0.10", default_features = true, features = ["serialize"]}
+bevy = {version = "0.12", default_features = true, features = ["serialize"]}
 
 [lib]
 name = "leafwing_input_playback"

--- a/examples/gamepad.rs
+++ b/examples/gamepad.rs
@@ -17,15 +17,17 @@ fn main() {
 
     App::new()
         // This plugin contains all the code from the original example
-        .add_plugin(GamepadViewerExample)
-        .add_plugin(InputCapturePlugin)
-        .add_plugin(InputPlaybackPlugin)
+        .add_plugins((
+            GamepadViewerExample,
+            InputCapturePlugin,
+            InputPlaybackPlugin,
+        ))
         // Disable all input capture and playback to start
         .insert_resource(InputModesCaptured::DISABLE_ALL)
         .insert_resource(PlaybackStrategy::Paused)
         // Toggle between playback and capture using Space
         .insert_resource(InputStrategy::Playback)
-        .add_system(toggle_capture_vs_playback)
+        .add_systems(Update, toggle_capture_vs_playback)
         .run();
 }
 
@@ -88,14 +90,19 @@ mod gamepad_viewer_example {
                 .init_resource::<ButtonMaterials>()
                 .init_resource::<ButtonMeshes>()
                 .init_resource::<FontHandle>()
-                .add_startup_system(setup)
-                .add_startup_system(setup_sticks)
-                .add_startup_system(setup_triggers)
-                .add_startup_system(setup_connected)
-                .add_system(update_buttons)
-                .add_system(update_button_values)
-                .add_system(update_axes)
-                .add_system(update_connected);
+                .add_systems(
+                    Startup,
+                    (setup, setup_sticks, setup_triggers, setup_connected),
+                )
+                .add_systems(
+                    Update,
+                    (
+                        update_buttons,
+                        update_button_values,
+                        update_axes,
+                        update_connected,
+                    ),
+                );
         }
     }
 
@@ -527,7 +534,7 @@ mod gamepad_viewer_example {
         mut events: EventReader<GamepadEvent>,
         mut query: Query<(&mut Text, &TextWithButtonValue)>,
     ) {
-        for event in events.iter() {
+        for event in events.read() {
             if let GamepadEvent::Button(GamepadButtonChangedEvent {
                 gamepad: _,
                 button_type,
@@ -548,7 +555,7 @@ mod gamepad_viewer_example {
         mut query: Query<(&mut Transform, &MoveWithAxes)>,
         mut text_query: Query<(&mut Text, &TextWithAxes)>,
     ) {
-        for event in events.iter() {
+        for event in events.read() {
             if let GamepadEvent::Axis(axis_changed_event) = event {
                 let axis_type = axis_changed_event.axis_type;
                 let value = axis_changed_event.value;

--- a/examples/input_capture.rs
+++ b/examples/input_capture.rs
@@ -5,9 +5,8 @@ use leafwing_input_playback::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(InputCapturePlugin)
-        .add_system(debug_input_capture)
+        .add_plugins((DefaultPlugins, InputCapturePlugin))
+        .add_systems(Update, debug_input_capture)
         .run()
 }
 

--- a/examples/input_playback.rs
+++ b/examples/input_playback.rs
@@ -8,20 +8,19 @@ use leafwing_input_playback::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(InputCapturePlugin)
-        .add_plugin(InputPlaybackPlugin)
+        .add_plugins((DefaultPlugins, InputCapturePlugin, InputPlaybackPlugin))
         // Disable all input capture and playback to start
         .insert_resource(InputModesCaptured::DISABLE_ALL)
         .insert_resource(PlaybackStrategy::Paused)
         // Creates a little game that spawns decaying boxes where the player clicks
         .insert_resource(ClearColor(Color::rgb(0.9, 0.9, 0.9)))
-        .add_startup_system(setup)
-        .add_system(spawn_boxes)
-        .add_system(decay_boxes)
+        .add_systems(Startup, setup)
+        .add_systems(
+            Update,
+            (spawn_boxes, decay_boxes, toggle_capture_vs_playback),
+        )
         // Toggle between playback and capture by pressing Space
         .insert_resource(InputStrategy::Playback)
-        .add_system(toggle_capture_vs_playback)
         .run()
 }
 

--- a/examples/playback_serialized_input.rs
+++ b/examples/playback_serialized_input.rs
@@ -6,15 +6,14 @@ use leafwing_input_playback::serde::PlaybackFilePath;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(InputPlaybackPlugin)
+        .add_plugins((DefaultPlugins, InputPlaybackPlugin))
         .insert_resource(PlaybackFilePath::new("./data/hello_world.ron"))
-        .add_system(debug_keyboard_inputs)
+        .add_systems(Update, debug_keyboard_inputs)
         .run();
 }
 
 fn debug_keyboard_inputs(mut keyboard_events: EventReader<KeyboardInput>) {
-    for keyboard_event in keyboard_events.iter() {
+    for keyboard_event in keyboard_events.read() {
         dbg!(keyboard_event);
     }
 }

--- a/examples/serialize_captured_input.rs
+++ b/examples/serialize_captured_input.rs
@@ -7,8 +7,7 @@ use leafwing_input_playback::serde::PlaybackFilePath;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(InputCapturePlugin)
+        .add_plugins((DefaultPlugins, InputCapturePlugin))
         .insert_resource(PlaybackFilePath::new("./data/test_playback.ron"))
         // In this example, we're only capturing keyboard inputs
         .insert_resource(InputModesCaptured {

--- a/examples/useless_machine.rs
+++ b/examples/useless_machine.rs
@@ -8,8 +8,7 @@ use leafwing_input_playback::serde::PlaybackFilePath;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(InputPlaybackPlugin)
+        .add_plugins((DefaultPlugins, InputPlaybackPlugin))
         .insert_resource(PlaybackFilePath::new("./data/app_exit.ron"))
         .run();
 }

--- a/src/frame_counting.rs
+++ b/src/frame_counting.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::ops::{Add, Sub};
 /// The number of frames that have elapsed since the app started
 ///
-/// Updated in [`time_tracker`] during [`CoreStage::First`].
+/// Updated in [`time_tracker`] during the [`First`] schedule.
 #[derive(
     Resource,
     Clone,
@@ -38,7 +38,7 @@ impl Sub<FrameCount> for FrameCount {
 
 /// A system which increases the value of the [`FrameCount`] resource by 1 every frame
 ///
-/// This system should run during [`CoreStage::First`].
+/// This system should run during the [`First`] schedule.
 pub fn frame_counter(mut frame_count: ResMut<FrameCount>) {
     frame_count.0 += 1;
 }

--- a/src/input_capture.rs
+++ b/src/input_capture.rs
@@ -2,7 +2,7 @@
 //!
 //! These are unified into a single [`TimestampedInputs`](crate::timestamped_input::TimestampedInputs) resource, which can be played back.
 
-use bevy::app::{App, AppExit, CoreSet, Plugin};
+use bevy::app::{App, AppExit, First, Last, Plugin};
 use bevy::ecs::prelude::*;
 use bevy::input::gamepad::GamepadEvent;
 use bevy::input::keyboard::KeyboardInput;
@@ -30,20 +30,20 @@ impl Plugin for InputCapturePlugin {
         // Avoid double-adding frame_counter
         if !app.world.contains_resource::<FrameCount>() {
             app.init_resource::<FrameCount>()
-                .add_system(frame_counter.in_base_set(CoreSet::First));
+                .add_systems(First, frame_counter);
         }
 
         app.init_resource::<TimestampedInputs>()
             .init_resource::<InputModesCaptured>()
             .init_resource::<PlaybackFilePath>()
-            .add_system(
-                // Capture any mocked input as well
-                capture_input.in_base_set(CoreSet::Last),
-            )
-            .add_system(
-                serialize_captured_input_on_exit
-                    .in_base_set(CoreSet::Last)
-                    .after(capture_input),
+            .add_systems(
+                Last,
+                (
+                    // Capture any mocked input as well
+                    capture_input,
+                    serialize_captured_input_on_exit,
+                )
+                    .chain(),
             );
     }
 }
@@ -118,33 +118,42 @@ pub fn capture_input(
         timestamped_input.send_multiple(
             frame,
             time_since_startup,
-            mouse_button_events.iter().cloned(),
+            mouse_button_events.read().cloned(),
         );
 
         timestamped_input.send_multiple(
             frame,
             time_since_startup,
-            mouse_wheel_events.iter().cloned(),
+            mouse_wheel_events.read().cloned(),
         );
+    } else {
+        mouse_button_events.clear();
+        mouse_wheel_events.clear();
     }
 
     if input_modes_captured.mouse_motion {
         timestamped_input.send_multiple(
             frame,
             time_since_startup,
-            cursor_moved_events.iter().cloned(),
+            cursor_moved_events.read().cloned(),
         );
+    } else {
+        cursor_moved_events.clear();
     }
 
     if input_modes_captured.keyboard {
-        timestamped_input.send_multiple(frame, time_since_startup, keyboard_events.iter().cloned());
+        timestamped_input.send_multiple(frame, time_since_startup, keyboard_events.read().cloned());
+    } else {
+        keyboard_events.clear()
     }
 
     if input_modes_captured.gamepad {
-        timestamped_input.send_multiple(frame, time_since_startup, gamepad_events.iter().cloned());
+        timestamped_input.send_multiple(frame, time_since_startup, gamepad_events.read().cloned());
+    } else {
+        gamepad_events.clear()
     }
 
-    timestamped_input.send_multiple(frame, time_since_startup, app_exit_events.iter().cloned())
+    timestamped_input.send_multiple(frame, time_since_startup, app_exit_events.read().cloned())
 }
 
 /// Serializes captured input to the path given in the [`PlaybackFilePath`] resource.

--- a/src/input_playback.rs
+++ b/src/input_playback.rs
@@ -22,7 +22,7 @@ use crate::timestamped_input::{TimestampedInputEvent, TimestampedInputs};
 
 /// Reads from the [`TimestampedInputs`] event stream to determine which events to play back.
 ///
-/// Events are played back during [`CoreStage::First`] to accurately mimic the behavior of native `winit`-based inputs.
+/// Events are played back during the [`First`] schedule to accurately mimic the behavior of native `winit`-based inputs.
 /// Which events are played back are controlled via the [`PlaybackStrategy`] resource.
 ///  
 /// Input is deserialized on app startup from the path stored in the [`PlaybackFilePath`] resource, if any.

--- a/src/input_playback.rs
+++ b/src/input_playback.rs
@@ -2,7 +2,7 @@
 //!
 //! These are played back by emulating assorted Bevy input events.
 
-use bevy::app::{App, AppExit, CoreSet, Plugin};
+use bevy::app::{App, AppExit, First, Plugin, Startup};
 use bevy::ecs::{prelude::*, system::SystemParam};
 use bevy::input::gamepad::GamepadEvent;
 use bevy::input::{
@@ -33,19 +33,15 @@ impl Plugin for InputPlaybackPlugin {
         // Avoid double-adding frame_counter
         if !app.world.contains_resource::<FrameCount>() {
             app.init_resource::<FrameCount>()
-                .add_system(frame_counter.in_base_set(CoreSet::First));
+                .add_systems(First, frame_counter);
         }
 
         app.init_resource::<TimestampedInputs>()
             .init_resource::<PlaybackProgress>()
             .init_resource::<PlaybackStrategy>()
             .init_resource::<PlaybackFilePath>()
-            .add_startup_system(deserialize_timestamped_inputs)
-            .add_system(
-                playback_timestamped_input
-                    .after(frame_counter)
-                    .in_base_set(CoreSet::First),
-            );
+            .add_systems(Startup, deserialize_timestamped_inputs)
+            .add_systems(First, playback_timestamped_input.after(frame_counter));
     }
 }
 

--- a/src/timestamped_input.rs
+++ b/src/timestamped_input.rs
@@ -410,11 +410,13 @@ mod tests {
     const LEFT_CLICK_PRESS: InputEvent = InputEvent::MouseButton(MouseButtonInput {
         button: MouseButton::Left,
         state: ButtonState::Pressed,
+        window: Entity::PLACEHOLDER,
     });
 
     const LEFT_CLICK_RELEASE: InputEvent = InputEvent::MouseButton(MouseButtonInput {
         button: MouseButton::Left,
         state: ButtonState::Released,
+        window: Entity::PLACEHOLDER,
     });
 
     fn complex_timestamped_input() -> TimestampedInputs {

--- a/tests/input_capture.rs
+++ b/tests/input_capture.rs
@@ -15,26 +15,31 @@ const TEST_PRESS: KeyboardInput = KeyboardInput {
     scan_code: 1,
     key_code: Some(KeyCode::F),
     state: ButtonState::Pressed,
+    window: Entity::PLACEHOLDER,
 };
 
 const TEST_RELEASE: KeyboardInput = KeyboardInput {
     scan_code: 1,
     key_code: Some(KeyCode::F),
     state: ButtonState::Released,
+    window: Entity::PLACEHOLDER,
 };
 
 const TEST_MOUSE: MouseButtonInput = MouseButtonInput {
     button: MouseButton::Left,
     state: ButtonState::Pressed,
+    window: Entity::PLACEHOLDER,
 };
 
 fn capture_app() -> App {
     let mut app = App::new();
 
-    app.add_plugins(MinimalPlugins)
-        .add_plugin(WindowPlugin::default())
-        .add_plugin(InputPlugin)
-        .add_plugin(InputCapturePlugin);
+    app.add_plugins((
+        MinimalPlugins,
+        WindowPlugin::default(),
+        InputPlugin,
+        InputCapturePlugin,
+    ));
 
     app
 }

--- a/tests/input_playback.rs
+++ b/tests/input_playback.rs
@@ -19,21 +19,25 @@ const TEST_PRESS: KeyboardInput = KeyboardInput {
     scan_code: 1,
     key_code: Some(KeyCode::F),
     state: ButtonState::Pressed,
+    window: Entity::PLACEHOLDER,
 };
 
 const TEST_RELEASE: KeyboardInput = KeyboardInput {
     scan_code: 1,
     key_code: Some(KeyCode::F),
     state: ButtonState::Released,
+    window: Entity::PLACEHOLDER,
 };
 
 fn playback_app(strategy: PlaybackStrategy) -> App {
     let mut app = App::new();
 
-    app.add_plugins(MinimalPlugins)
-        .add_plugin(WindowPlugin::default())
-        .add_plugin(InputPlugin)
-        .add_plugin(InputPlaybackPlugin);
+    app.add_plugins((
+        MinimalPlugins,
+        WindowPlugin::default(),
+        InputPlugin,
+        InputPlaybackPlugin,
+    ));
 
     *app.world.resource_mut::<PlaybackStrategy>() = strategy;
 
@@ -85,7 +89,7 @@ fn minimal_playback() {
 #[test]
 fn capture_and_playback() {
     let mut app = playback_app(PlaybackStrategy::default());
-    app.add_plugin(InputCapturePlugin);
+    app.add_plugins(InputCapturePlugin);
     app.insert_resource(PlaybackStrategy::Paused);
 
     let mut input_events = app.world.resource_mut::<Events<KeyboardInput>>();

--- a/tests/input_playback.rs
+++ b/tests/input_playback.rs
@@ -38,7 +38,8 @@ fn playback_app(strategy: PlaybackStrategy) -> App {
         InputPlugin,
         InputPlaybackPlugin,
     ));
-
+    app.world
+        .remove_resource::<bevy::ecs::event::EventUpdateSignal>();
     *app.world.resource_mut::<PlaybackStrategy>() = strategy;
 
     app


### PR DESCRIPTION
### Changes

This PR upgrades Bevy to version 0.12.

Most changes are required by updates to Bevy's API:
- `add_plugin` -> `add_plugins`
- `add_system` -> `add_systems` and removing `in_base_set` in favor of Schedule
- `EventReader::iter` -> `EventReader::read`
- adding `Entity::PLACEHOLDER` as the window entity for input events in tests

### TODOs

Some tests are currently failing in `tests/input_playback.rs`:
- `repeated_playback`
- `playback_strategy_frame_range_once`
- `playback_strategy_frame_range_loop`

This is definitely due to changes to `Events` in the last two versions, but I haven't figured out the correct solution yet. I'll take another look soon to try to figure it out if no one else gets to it before me.

### Misc Notes

- Could not find the `dev` branch mentioned in the [contribution guide](https://github.com/Leafwing-Studios/leafwing_input_playback/blob/c1779b5ba47f283672e49f4dbece8ffaa76c8723/CONTRIBUTING.md).