### PR TITLE
Upgrade to bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ members = ["./", "tools/ci"]
 default = []
 
 [dependencies]
-bevy = { version = "0.13", default_features = false, features = ["serialize"] }
+bevy = { version = "0.14", default-features = false, features = ["serialize"] }
 serde = { version = "1.0", features = ["derive"] }
 ron = "0.8"
 
 [dev-dependencies]
-bevy = { version = "0.13", default_features = true, features = ["serialize"] }
+bevy = { version = "0.14", default-features = true, features = ["serialize"] }
 smol_str = "0.2"
 
 [lib]

--- a/examples/gamepad.rs
+++ b/examples/gamepad.rs
@@ -109,6 +109,7 @@ mod gamepad_viewer_example {
     use std::f32::consts::PI;
 
     use bevy::{
+        color::palettes,
         input::gamepad::{GamepadButton, GamepadButtonChangedEvent, GamepadEvent, GamepadSettings},
         prelude::*,
         sprite::{MaterialMesh2dBundle, Mesh2dHandle},
@@ -125,11 +126,11 @@ mod gamepad_viewer_example {
     const STICKS_X: f32 = 150.;
     const STICKS_Y: f32 = -135.;
 
-    const NORMAL_BUTTON_COLOR: Color = Color::rgb(0.2, 0.2, 0.2);
-    const ACTIVE_BUTTON_COLOR: Color = Color::PURPLE;
-    const LIVE_COLOR: Color = Color::rgb(0.4, 0.4, 0.4);
-    const DEAD_COLOR: Color = Color::rgb(0.3, 0.3, 0.3);
-    const EXTENT_COLOR: Color = Color::rgb(0.3, 0.3, 0.3);
+    const NORMAL_BUTTON_COLOR: Color = Color::srgb(0.2, 0.2, 0.2);
+    const ACTIVE_BUTTON_COLOR: Color = Color::Srgba(palettes::css::PURPLE);
+    const LIVE_COLOR: Color = Color::srgb(0.4, 0.4, 0.4);
+    const DEAD_COLOR: Color = Color::srgb(0.3, 0.3, 0.3);
+    const EXTENT_COLOR: Color = Color::srgb(0.3, 0.3, 0.3);
     const TEXT_COLOR: Color = Color::WHITE;
 
     #[derive(Component, Deref)]

--- a/examples/input_capture.rs
+++ b/examples/input_capture.rs
@@ -3,7 +3,7 @@ use leafwing_input_playback::{
     input_capture::InputCapturePlugin, timestamped_input::TimestampedInputs,
 };
 
-fn main() {
+fn main() -> AppExit {
     App::new()
         .add_plugins((DefaultPlugins, InputCapturePlugin))
         .add_systems(Update, debug_input_capture)

--- a/examples/input_playback.rs
+++ b/examples/input_playback.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, window::PrimaryWindow};
+use bevy::{color::palettes, prelude::*, window::PrimaryWindow};
 
 use leafwing_input_playback::{
     input_capture::{InputCapturePlugin, InputModesCaptured},
@@ -6,14 +6,14 @@ use leafwing_input_playback::{
     timestamped_input::TimestampedInputs,
 };
 
-fn main() {
+fn main() -> AppExit {
     App::new()
         .add_plugins((DefaultPlugins, InputCapturePlugin, InputPlaybackPlugin))
         // Disable all input capture and playback to start
         .insert_resource(InputModesCaptured::DISABLE_ALL)
         .insert_resource(PlaybackStrategy::Paused)
         // Creates a little game that spawns decaying boxes where the player clicks
-        .insert_resource(ClearColor(Color::rgb(0.9, 0.9, 0.9)))
+        .insert_resource(ClearColor(Color::srgb(0.9, 0.9, 0.9)))
         .add_systems(Startup, setup)
         .add_systems(
             Update,
@@ -43,7 +43,7 @@ pub fn cursor_pos_as_world_pos(
         let window_size = Vec2::new(current_window.width(), current_window.height());
 
         // Convert screen position [0..resolution] to ndc [-1..1]
-        let ndc_to_world = cam_t.compute_matrix() * cam.projection_matrix().inverse();
+        let ndc_to_world = cam_t.compute_matrix() * cam.clip_from_view().inverse();
         let ndc = (Vec2::new(cursor_pos.x, cursor_pos.y) / window_size) * 2.0 - Vec2::ONE;
         let world_pos = ndc_to_world.project_point3(ndc.extend(-1.0));
         world_pos.truncate()
@@ -68,7 +68,7 @@ fn spawn_boxes(
             commands
                 .spawn(SpriteBundle {
                     sprite: Sprite {
-                        color: Color::DARK_GREEN,
+                        color: Color::Srgba(palettes::css::DARK_GREEN),
                         ..default()
                     },
                     transform: Transform {

--- a/src/input_capture.rs
+++ b/src/input_capture.rs
@@ -178,6 +178,7 @@ pub fn serialize_timestamped_inputs(
     if let Some(file_path) = playback_file.path() {
         let mut file = OpenOptions::new()
             .create(true)
+            .truncate(true)
             .write(true)
             .open(file_path)
             .expect("Could not open file.");

--- a/src/input_capture.rs
+++ b/src/input_capture.rs
@@ -28,7 +28,7 @@ pub struct InputCapturePlugin;
 impl Plugin for InputCapturePlugin {
     fn build(&self, app: &mut App) {
         // Avoid double-adding frame_counter
-        if !app.world.contains_resource::<FrameCount>() {
+        if !app.world().contains_resource::<FrameCount>() {
             app.init_resource::<FrameCount>()
                 .add_systems(First, frame_counter);
         }

--- a/src/input_playback.rs
+++ b/src/input_playback.rs
@@ -31,7 +31,7 @@ pub struct InputPlaybackPlugin;
 impl Plugin for InputPlaybackPlugin {
     fn build(&self, app: &mut App) {
         // Avoid double-adding frame_counter
-        if !app.world.contains_resource::<FrameCount>() {
+        if !app.world().contains_resource::<FrameCount>() {
             app.init_resource::<FrameCount>()
                 .add_systems(First, frame_counter);
         }

--- a/src/input_playback.rs
+++ b/src/input_playback.rs
@@ -33,7 +33,7 @@ impl Plugin for InputPlaybackPlugin {
         // Avoid double-adding frame_counter
         if !app.world().contains_resource::<FrameCount>() {
             app.init_resource::<FrameCount>()
-                .add_systems(First, frame_counter);
+                .add_systems(First, frame_counter.after(bevy::ecs::event::EventUpdates));
         }
 
         app.init_resource::<TimestampedInputs>()

--- a/tests/input_capture.rs
+++ b/tests/input_capture.rs
@@ -49,12 +49,12 @@ fn capture_app() -> App {
 fn capture_sent_events() {
     let mut app = capture_app();
 
-    let mut keyboard_events = app.world.resource_mut::<Events<KeyboardInput>>();
+    let mut keyboard_events = app.world_mut().resource_mut::<Events<KeyboardInput>>();
     keyboard_events.send(TEST_PRESS);
     keyboard_events.send(TEST_RELEASE);
 
     app.update();
-    let timestamped_input = app.world.resource::<TimestampedInputs>();
+    let timestamped_input = app.world().resource::<TimestampedInputs>();
     assert_eq!(timestamped_input.len(), 2);
 }
 
@@ -62,17 +62,17 @@ fn capture_sent_events() {
 fn identity_of_sent_events() {
     let mut app = capture_app();
 
-    let mut keyboard_events = app.world.resource_mut::<Events<KeyboardInput>>();
+    let mut keyboard_events = app.world_mut().resource_mut::<Events<KeyboardInput>>();
     keyboard_events.send(TEST_PRESS);
 
     // Events within the same frame are not ordered reliably
     app.update();
 
-    let mut mouse_events = app.world.resource_mut::<Events<MouseButtonInput>>();
+    let mut mouse_events = app.world_mut().resource_mut::<Events<MouseButtonInput>>();
     mouse_events.send(TEST_MOUSE);
 
     app.update();
-    let mut timestamped_input = app.world.resource_mut::<TimestampedInputs>();
+    let mut timestamped_input = app.world_mut().resource_mut::<TimestampedInputs>();
     let mut iterator = timestamped_input.iter_all().into_iter();
 
     let first_event: TimestampedInputEvent = iterator.next().unwrap();
@@ -90,16 +90,16 @@ fn identity_of_sent_events() {
 fn framecount_of_sent_events() {
     let mut app = capture_app();
 
-    let mut keyboard_events = app.world.resource_mut::<Events<KeyboardInput>>();
+    let mut keyboard_events = app.world_mut().resource_mut::<Events<KeyboardInput>>();
     keyboard_events.send(TEST_PRESS);
 
     app.update();
 
-    let mut mouse_events = app.world.resource_mut::<Events<MouseButtonInput>>();
+    let mut mouse_events = app.world_mut().resource_mut::<Events<MouseButtonInput>>();
     mouse_events.send(TEST_MOUSE);
 
     app.update();
-    let mut timestamped_input = app.world.resource_mut::<TimestampedInputs>();
+    let mut timestamped_input = app.world_mut().resource_mut::<TimestampedInputs>();
     let mut iterator = timestamped_input.iter_all().into_iter();
 
     let first_event: TimestampedInputEvent = iterator.next().expect("Keyboard event failed.");
@@ -115,47 +115,47 @@ fn framecount_of_sent_events() {
 fn toggle_input_capture() {
     let mut app = capture_app();
 
-    let mut keyboard_events = app.world.resource_mut::<Events<KeyboardInput>>();
+    let mut keyboard_events = app.world_mut().resource_mut::<Events<KeyboardInput>>();
     keyboard_events.send(TEST_PRESS);
     keyboard_events.send(TEST_RELEASE);
 
     app.update();
 
     // Inputs are captured while input capturing is enabled by default
-    let timestamped_input = app.world.resource::<TimestampedInputs>();
+    let timestamped_input = app.world().resource::<TimestampedInputs>();
     assert_eq!(timestamped_input.len(), 2);
 
     // Disabling input capture
-    let mut input_modes_captured = app.world.resource_mut::<InputModesCaptured>();
+    let mut input_modes_captured = app.world_mut().resource_mut::<InputModesCaptured>();
     *input_modes_captured = InputModesCaptured::DISABLE_ALL;
 
-    let mut keyboard_events = app.world.resource_mut::<Events<KeyboardInput>>();
+    let mut keyboard_events = app.world_mut().resource_mut::<Events<KeyboardInput>>();
     keyboard_events.send(TEST_PRESS);
     keyboard_events.send(TEST_RELEASE);
 
     app.update();
 
     // Inputs are not captured while input capturing is disabled
-    let timestamped_input = app.world.resource::<TimestampedInputs>();
+    let timestamped_input = app.world().resource::<TimestampedInputs>();
     assert_eq!(timestamped_input.len(), 2);
 
     // Partially re-enabling input capture
-    let mut input_modes_captured = app.world.resource_mut::<InputModesCaptured>();
+    let mut input_modes_captured = app.world_mut().resource_mut::<InputModesCaptured>();
     *input_modes_captured = InputModesCaptured {
         mouse_buttons: false,
         keyboard: true,
         ..Default::default()
     };
 
-    let mut keyboard_events = app.world.resource_mut::<Events<KeyboardInput>>();
+    let mut keyboard_events = app.world_mut().resource_mut::<Events<KeyboardInput>>();
     keyboard_events.send(TEST_PRESS);
 
-    let mut mouse_events = app.world.resource_mut::<Events<MouseButtonInput>>();
+    let mut mouse_events = app.world_mut().resource_mut::<Events<MouseButtonInput>>();
     mouse_events.send(TEST_MOUSE);
 
     app.update();
 
     // Only the keyboard events (and app exit events) were captured
-    let timestamped_input = app.world.resource::<TimestampedInputs>();
+    let timestamped_input = app.world().resource::<TimestampedInputs>();
     assert_eq!(timestamped_input.len(), 3);
 }

--- a/tests/input_playback.rs
+++ b/tests/input_playback.rs
@@ -1,5 +1,6 @@
 // BLOCKED: add time strategy tests: https://github.com/bevyengine/bevy/issues/6146
 
+use bevy::ecs::event::EventRegistry;
 use bevy::input::keyboard::Key;
 use bevy::input::keyboard::KeyboardInput;
 use bevy::input::ButtonState;
@@ -7,10 +8,9 @@ use bevy::input::InputPlugin;
 use bevy::prelude::*;
 use bevy::time::TimeUpdateStrategy;
 use bevy::utils::Duration;
-
 use bevy::window::WindowPlugin;
-use leafwing_input_playback::frame_counting::FrameCount;
 
+use leafwing_input_playback::frame_counting::FrameCount;
 use leafwing_input_playback::input_capture::InputCapturePlugin;
 use leafwing_input_playback::input_capture::InputModesCaptured;
 use leafwing_input_playback::input_playback::InputPlaybackPlugin;
@@ -40,6 +40,10 @@ fn playback_app(strategy: PlaybackStrategy) -> App {
         InputPlugin,
         InputPlaybackPlugin,
     ));
+
+    let mut registry = app.world_mut().resource_mut::<EventRegistry>();
+    registry.should_update = ShouldUpdateEvents::Always;
+
     *app.world_mut().resource_mut::<PlaybackStrategy>() = strategy;
 
     app

--- a/tests/input_playback.rs
+++ b/tests/input_playback.rs
@@ -1,6 +1,5 @@
 // BLOCKED: add time strategy tests: https://github.com/bevyengine/bevy/issues/6146
 
-use bevy::ecs::event::EventRegistry;
 use bevy::input::keyboard::Key;
 use bevy::input::keyboard::KeyboardInput;
 use bevy::input::ButtonState;
@@ -41,9 +40,6 @@ fn playback_app(strategy: PlaybackStrategy) -> App {
         InputPlugin,
         InputPlaybackPlugin,
     ));
-
-    let mut registry = app.world_mut().resource_mut::<EventRegistry>();
-    registry.should_update = ShouldUpdateEvents::Always;
     *app.world_mut().resource_mut::<PlaybackStrategy>() = strategy;
 
     app
@@ -71,13 +67,14 @@ fn complex_timestamped_input() -> TimestampedInputs {
 #[test]
 fn minimal_playback() {
     let mut app = playback_app(PlaybackStrategy::FrameCount);
-
     let input_events = app.world().resource::<Events<KeyboardInput>>();
     assert_eq!(input_events.len(), 0);
+
     *app.world_mut().resource_mut::<TimestampedInputs>() = simple_timestamped_input();
 
     app.update();
 
+    // By default, only events up to the current frame are played back
     let input_events = app.world().resource::<Events<KeyboardInput>>();
     assert_eq!(input_events.len(), 1);
     let input = app.world().resource::<ButtonInput<KeyCode>>();
@@ -85,7 +82,8 @@ fn minimal_playback() {
 
     app.update();
     let input_events = app.world().resource::<Events<KeyboardInput>>();
-    assert_eq!(input_events.len(), 1);
+    // Events are double-buffered
+    assert_eq!(input_events.len(), 2);
     let input = app.world().resource::<ButtonInput<KeyCode>>();
     assert!(!input.pressed(KeyCode::KeyF));
 }
@@ -170,7 +168,6 @@ fn playback_strategy_paused() {
 #[test]
 fn playback_strategy_frame() {
     let mut app = playback_app(PlaybackStrategy::FrameCount);
-
     *app.world_mut().resource_mut::<TimestampedInputs>() = complex_timestamped_input();
 
     let timestamped_input = app.world().resource::<TimestampedInputs>();
@@ -211,13 +208,13 @@ fn playback_strategy_frame_range_once() {
     // Frame 3 (events are double buffered)
     app.update();
     let input_events = app.world().resource::<Events<KeyboardInput>>();
-    assert_eq!(input_events.len(), 1);
+    assert_eq!(input_events.len(), 3);
 
     // Frame 4 (events are double buffered)
     app.update();
     let input_events = app.world().resource::<Events<KeyboardInput>>();
     assert_eq!(*app.world().resource::<PlaybackStrategy>(), strategy);
-    assert_eq!(input_events.len(), 0);
+    assert_eq!(input_events.len(), 1);
 
     // Paused
     app.update();
@@ -249,13 +246,13 @@ fn playback_strategy_frame_range_loop() {
     // Frame 3 (events are double buffered)
     app.update();
     let input_events = app.world().resource::<Events<KeyboardInput>>();
-    assert_eq!(input_events.len(), 1);
+    assert_eq!(input_events.len(), 3);
 
     // Frame 4 (events are double buffered)
     app.update();
     let input_events = app.world().resource::<Events<KeyboardInput>>();
     assert_eq!(*app.world().resource::<PlaybackStrategy>(), strategy);
-    assert_eq!(input_events.len(), 0);
+    assert_eq!(input_events.len(), 1);
 
     // Spacing frame
     app.update();


### PR DESCRIPTION
# Issue

This upgrades Bevy to 0.14.

# Changes

Most changes relate to color APIs, `app.world()` and `app.world_mut()`. Other changes include:

- Returning `AppExit` from example `main` functions
- Removing the test code that removes `EventUpdateSignal`, which no longer exists
- Set `ShouldUpdateEvents::Always` on `EventRegistry` for playback tests and ~~updated test assertions in `FrameCount`-related tests not to expect double buffering.~~ configure `InputPlaybackPlugin` systems in `First` to occur after events flush to fix tests and guarantee correct system ordering.

# ~~Questions / TODOs~~ Solved! Skip this :)

This last bit is potentially controversial but I didn't want to submit a PR with an incomplete solution even if I wasn't entirely confident in the more complete one.

Without this last change (feel free to try the commit, it's `432c5a7`), there are issues with the `input-playback.rs` tests using `PlaybackStrategy::FrameCount`. Specifically, the `Event` buffers in these tests are not flushing each update unless `ShouldUpdateEvents::Always` is set on the `EventRegistry` resource. Then, if `ShouldUpdateEvents::Always` is set, the buffer flushes at the end of the `update` call, so the test code that follows `app.update()` sees an empty "front" buffer (to accept input in the next update call) and the events of the last update in the "back" buffer. This makes sense (that is the "last frame" now), but does imply that something needs to change.

To provide some concrete example behaviors, this creates issues in the `frame_range_once` and `frame_range_loop` tests, which specifically check for double-buffering behavior. Without `ShouldUpdateEvents::Always`, event counts simply accumulate, but with it included, the tests still fail because they expect double-buffered event counts. Additionally, the comment at `tests/input_playback.rs#87` is now misleading: that `input_events` variable originally has both events in the `events_a` buffer, and if we set `ShouldUpdateEvents::Always`, it is the same but for the `events_b` buffer. This is not representative of double-buffering.

This is also true if we read the input events during `playback_strategy_frame` and other tests. The one test that does not have this behavior is `repeated_playback` which sets a `TimeUpdateStrategy::ManualDuration` and probably triggers `FixedUpdate`, which would set `ShouldUpdateEvents::Ready` and execute a flush.

It didn't seem as appropriate to wrangle `FixedUpdate` or manually trigger event flushes, nor to make assertions inside `Update` or `PostUpdate` somehow so that we _could_ observe the double-buffering, which is why I took the approach of not expecting double-buffered events in these tests.

Seems like `Event`s have gone through a few changes in the past few versions and I'm not an expert on all them, so please let me know if there is a preferable approach!