### PR TITLE
Upgrade Bevy to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,10 @@ members = ["./", "tools/ci"]
 default = []
 
 [dependencies]
-bevy = { version = "0.15", default-features = false, features = ["serialize"] }
+bevy = { version = "0.15", default-features = false, features = [
+    "bevy_window",
+    "serialize",
+] }
 serde = { version = "1.0", features = ["derive"] }
 ron = "0.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ members = ["./", "tools/ci"]
 default = []
 
 [dependencies]
-bevy = { version = "0.14", default-features = false, features = ["serialize"] }
+bevy = { version = "0.15", default-features = false, features = ["serialize"] }
 serde = { version = "1.0", features = ["derive"] }
 ron = "0.8"
 
 [dev-dependencies]
-bevy = { version = "0.14", default-features = true, features = ["serialize"] }
+bevy = { version = "0.15", default-features = true }
 smol_str = "0.2"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leafwing_input_playback"
 description = "Input recording and mocking functionality for the Bevy game engine."
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Leafwing Studios"]
 homepage = "https://leafwing-studios.com/"
 repository = "https://github.com/leafwing-studios/leafwing_input_playback"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## Version 0.6 (Draft)
+## Version 0.6
 
 - migrated to Bevy 0.14
 - replaced `FrameCount` with its Bevy counterpart and updated system scheduling constraints to match the new `FrameCount`'s behavior, which updates in `Last` rather than `First`

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,7 @@
 - migrated to Bevy 0.14
 - replaced `FrameCount` with its Bevy counterpart and updated system scheduling constraints to match the new `FrameCount`'s behavior, which updates in `Last` rather than `First`
 - refactored so that playback and capture are now initiated via Observers
+- migrated to Bevy 0.15
 
 ## Version 0.5
 

--- a/examples/gamepad.rs
+++ b/examples/gamepad.rs
@@ -112,7 +112,6 @@ mod gamepad_viewer_example {
         color::palettes,
         input::gamepad::{GamepadButton, GamepadButtonChangedEvent, GamepadEvent, GamepadSettings},
         prelude::*,
-        sprite::{MaterialMesh2dBundle, Mesh2dHandle},
     };
 
     const BUTTON_RADIUS: f32 = 25.;
@@ -131,23 +130,22 @@ mod gamepad_viewer_example {
     const LIVE_COLOR: Color = Color::srgb(0.4, 0.4, 0.4);
     const DEAD_COLOR: Color = Color::srgb(0.3, 0.3, 0.3);
     const EXTENT_COLOR: Color = Color::srgb(0.3, 0.3, 0.3);
-    const TEXT_COLOR: Color = Color::WHITE;
+    const TEXT_COLOR: TextColor = TextColor(Color::WHITE);
+
+    #[derive(Resource)]
+    struct DisplayGamepad(Entity);
+    #[derive(Component, Deref)]
+    struct ReactTo(GamepadButton);
+    #[derive(Clone, Copy, Component)]
+    enum GamepadStick {
+        Left,
+        Right,
+    }
+    #[derive(Component)]
+    struct ButtonScale(f32);
 
     #[derive(Component, Deref)]
-    struct ReactTo(GamepadButtonType);
-    #[derive(Component)]
-    struct MoveWithAxes {
-        x_axis: GamepadAxisType,
-        y_axis: GamepadAxisType,
-        scale: f32,
-    }
-    #[derive(Component)]
-    struct TextWithAxes {
-        x_axis: GamepadAxisType,
-        y_axis: GamepadAxisType,
-    }
-    #[derive(Component, Deref)]
-    struct TextWithButtonValue(GamepadButtonType);
+    struct TextWithButtonValue(GamepadButton);
 
     #[derive(Component)]
     struct ConnectedGamepadsText;
@@ -169,10 +167,10 @@ mod gamepad_viewer_example {
     }
     #[derive(Resource)]
     struct ButtonMeshes {
-        circle: Mesh2dHandle,
-        triangle: Mesh2dHandle,
-        start_pause: Mesh2dHandle,
-        trigger: Mesh2dHandle,
+        circle: Handle<Mesh>,
+        triangle: Handle<Mesh>,
+        start_pause: Handle<Mesh>,
+        trigger: Handle<Mesh>,
     }
 
     impl FromWorld for ButtonMeshes {
@@ -202,144 +200,135 @@ mod gamepad_viewer_example {
     }
 
     fn setup(mut commands: Commands, meshes: Res<ButtonMeshes>, materials: Res<ButtonMaterials>) {
-        commands.spawn(Camera2dBundle::default());
+        commands.spawn(Camera2d);
 
         // Buttons
 
         commands
-            .spawn(SpatialBundle {
-                transform: Transform::from_xyz(BUTTONS_X, BUTTONS_Y, 0.),
-                ..default()
-            })
+            .spawn((
+                Transform::from_xyz(BUTTONS_X, BUTTONS_Y, 0.),
+                Visibility::default(),
+            ))
             .with_children(|parent| {
                 parent
-                    .spawn(MaterialMesh2dBundle {
-                        mesh: meshes.circle.clone(),
-                        material: materials.normal.clone(),
-                        transform: Transform::from_xyz(0., BUTTON_CLUSTER_RADIUS, 0.),
-                        ..default()
-                    })
-                    .insert(ReactTo(GamepadButtonType::North));
+                    .spawn((
+                        Mesh2d(meshes.circle.clone()),
+                        MeshMaterial2d(materials.normal.clone()),
+                        Transform::from_xyz(0., BUTTON_CLUSTER_RADIUS, 0.),
+                    ))
+                    .insert(ReactTo(GamepadButton::North));
                 parent
-                    .spawn(MaterialMesh2dBundle {
-                        mesh: meshes.circle.clone(),
-                        material: materials.normal.clone(),
-                        transform: Transform::from_xyz(0., -BUTTON_CLUSTER_RADIUS, 0.),
-                        ..default()
-                    })
-                    .insert(ReactTo(GamepadButtonType::South));
+                    .spawn((
+                        Mesh2d(meshes.circle.clone()),
+                        MeshMaterial2d(materials.normal.clone()),
+                        Transform::from_xyz(0., -BUTTON_CLUSTER_RADIUS, 0.),
+                    ))
+                    .insert(ReactTo(GamepadButton::South));
                 parent
-                    .spawn(MaterialMesh2dBundle {
-                        mesh: meshes.circle.clone(),
-                        material: materials.normal.clone(),
-                        transform: Transform::from_xyz(-BUTTON_CLUSTER_RADIUS, 0., 0.),
-                        ..default()
-                    })
-                    .insert(ReactTo(GamepadButtonType::West));
+                    .spawn((
+                        Mesh2d(meshes.circle.clone()),
+                        MeshMaterial2d(materials.normal.clone()),
+                        Transform::from_xyz(-BUTTON_CLUSTER_RADIUS, 0., 0.),
+                    ))
+                    .insert(ReactTo(GamepadButton::West));
                 parent
-                    .spawn(MaterialMesh2dBundle {
-                        mesh: meshes.circle.clone(),
-                        material: materials.normal.clone(),
-                        transform: Transform::from_xyz(BUTTON_CLUSTER_RADIUS, 0., 0.),
-
-                        ..default()
-                    })
-                    .insert(ReactTo(GamepadButtonType::East));
+                    .spawn((
+                        Mesh2d(meshes.circle.clone()),
+                        MeshMaterial2d(materials.normal.clone()),
+                        Transform::from_xyz(BUTTON_CLUSTER_RADIUS, 0., 0.),
+                    ))
+                    .insert(ReactTo(GamepadButton::East));
             });
 
         // Start and Pause
 
         commands
-            .spawn(MaterialMesh2dBundle {
-                mesh: meshes.start_pause.clone(),
-                material: materials.normal.clone(),
-                transform: Transform::from_xyz(-30., BUTTONS_Y, 0.),
-                ..default()
-            })
-            .insert(ReactTo(GamepadButtonType::Select));
+            .spawn((
+                Mesh2d(meshes.start_pause.clone()),
+                MeshMaterial2d(materials.normal.clone()),
+                Transform::from_xyz(-30., BUTTONS_Y, 0.),
+            ))
+            .insert(ReactTo(GamepadButton::Select));
 
         commands
-            .spawn(MaterialMesh2dBundle {
-                mesh: meshes.start_pause.clone(),
-                material: materials.normal.clone(),
-                transform: Transform::from_xyz(30., BUTTONS_Y, 0.),
-                ..default()
-            })
-            .insert(ReactTo(GamepadButtonType::Start));
+            .spawn((
+                Mesh2d(meshes.start_pause.clone()),
+                MeshMaterial2d(materials.normal.clone()),
+                Transform::from_xyz(30., BUTTONS_Y, 0.),
+            ))
+            .insert(ReactTo(GamepadButton::Start));
 
         // D-Pad
 
         commands
-            .spawn(SpatialBundle {
-                transform: Transform::from_xyz(-BUTTONS_X, BUTTONS_Y, 0.),
-                ..default()
-            })
+            .spawn((
+                Transform::from_xyz(-BUTTONS_X, BUTTONS_Y, 0.),
+                Visibility::default(),
+            ))
             .with_children(|parent| {
                 parent
-                    .spawn(MaterialMesh2dBundle {
-                        mesh: meshes.triangle.clone(),
-                        material: materials.normal.clone(),
-                        transform: Transform::from_xyz(0., BUTTON_CLUSTER_RADIUS, 0.),
-                        ..default()
-                    })
-                    .insert(ReactTo(GamepadButtonType::DPadUp));
+                    .spawn((
+                        Mesh2d(meshes.triangle.clone()),
+                        MeshMaterial2d(materials.normal.clone()),
+                        Transform::from_xyz(0., BUTTON_CLUSTER_RADIUS, 0.),
+                    ))
+                    .insert(ReactTo(GamepadButton::DPadUp));
                 parent
-                    .spawn(MaterialMesh2dBundle {
-                        mesh: meshes.triangle.clone(),
-                        material: materials.normal.clone(),
-                        transform: Transform::from_xyz(0., -BUTTON_CLUSTER_RADIUS, 0.)
+                    .spawn((
+                        Mesh2d(meshes.triangle.clone()),
+                        MeshMaterial2d(materials.normal.clone()),
+                        Transform::from_xyz(0., -BUTTON_CLUSTER_RADIUS, 0.)
                             .with_rotation(Quat::from_rotation_z(PI)),
-                        ..default()
-                    })
-                    .insert(ReactTo(GamepadButtonType::DPadDown));
+                    ))
+                    .insert(ReactTo(GamepadButton::DPadDown));
                 parent
-                    .spawn(MaterialMesh2dBundle {
-                        mesh: meshes.triangle.clone(),
-                        material: materials.normal.clone(),
-                        transform: Transform::from_xyz(-BUTTON_CLUSTER_RADIUS, 0., 0.)
+                    .spawn((
+                        Mesh2d(meshes.triangle.clone()),
+                        MeshMaterial2d(materials.normal.clone()),
+                        Transform::from_xyz(-BUTTON_CLUSTER_RADIUS, 0., 0.)
                             .with_rotation(Quat::from_rotation_z(PI / 2.)),
-                        ..default()
-                    })
-                    .insert(ReactTo(GamepadButtonType::DPadLeft));
+                    ))
+                    .insert(ReactTo(GamepadButton::DPadLeft));
                 parent
-                    .spawn(MaterialMesh2dBundle {
-                        mesh: meshes.triangle.clone(),
-                        material: materials.normal.clone(),
-                        transform: Transform::from_xyz(BUTTON_CLUSTER_RADIUS, 0., 0.)
+                    .spawn((
+                        Mesh2d(meshes.triangle.clone()),
+                        MeshMaterial2d(materials.normal.clone()),
+                        Transform::from_xyz(BUTTON_CLUSTER_RADIUS, 0., 0.)
                             .with_rotation(Quat::from_rotation_z(-PI / 2.)),
-                        ..default()
-                    })
-                    .insert(ReactTo(GamepadButtonType::DPadRight));
+                    ))
+                    .insert(ReactTo(GamepadButton::DPadRight));
             });
 
         // Triggers
 
         commands
-            .spawn(MaterialMesh2dBundle {
-                mesh: meshes.trigger.clone(),
-                material: materials.normal.clone(),
-                transform: Transform::from_xyz(-BUTTONS_X, BUTTONS_Y + 115., 0.),
-                ..default()
-            })
-            .insert(ReactTo(GamepadButtonType::LeftTrigger));
+            .spawn((
+                Mesh2d(meshes.trigger.clone()),
+                MeshMaterial2d(materials.normal.clone()),
+                Transform::from_xyz(-BUTTONS_X, BUTTONS_Y + 115., 0.),
+            ))
+            .insert(ReactTo(GamepadButton::LeftTrigger));
 
         commands
-            .spawn(MaterialMesh2dBundle {
-                mesh: meshes.trigger.clone(),
-                material: materials.normal.clone(),
-                transform: Transform::from_xyz(BUTTONS_X, BUTTONS_Y + 115., 0.),
-                ..default()
-            })
-            .insert(ReactTo(GamepadButtonType::RightTrigger));
+            .spawn((
+                Mesh2d(meshes.trigger.clone()),
+                MeshMaterial2d(materials.normal.clone()),
+                Transform::from_xyz(BUTTONS_X, BUTTONS_Y + 115., 0.),
+            ))
+            .insert(ReactTo(GamepadButton::RightTrigger));
     }
 
     fn setup_sticks(
         mut commands: Commands,
         meshes: Res<ButtonMeshes>,
         materials: Res<ButtonMaterials>,
-        gamepad_settings: Res<GamepadSettings>,
+        gamepad_settings: Query<&GamepadSettings>,
         font: Res<FontHandle>,
     ) {
+        let Ok(gamepad_settings) = gamepad_settings.get_single() else {
+            eprintln!("NOOOO");
+            return;
+        };
         let dead_upper =
             STICK_BOUNDS_SIZE * gamepad_settings.default_axis_settings.deadzone_upperbound();
         let dead_lower =
@@ -354,100 +343,73 @@ mod gamepad_viewer_example {
         let live_size = live_lower.abs() + live_upper.abs();
         let live_mid = (live_lower + live_upper) / 2.0;
 
-        let mut spawn_stick = |x_pos, y_pos, x_axis, y_axis, button| {
+        let mut spawn_stick = |x_pos, y_pos, stick, button| {
             commands
-                .spawn(SpatialBundle {
-                    transform: Transform::from_xyz(x_pos, y_pos, 0.),
-                    ..default()
-                })
+                .spawn((Transform::from_xyz(x_pos, y_pos, 0.), Visibility::default()))
                 .with_children(|parent| {
                     // full extent
-                    parent.spawn(SpriteBundle {
-                        sprite: Sprite {
-                            custom_size: Some(Vec2::splat(STICK_BOUNDS_SIZE * 2.)),
-                            color: EXTENT_COLOR,
-                            ..default()
-                        },
+                    parent.spawn((Sprite {
+                        custom_size: Some(Vec2::splat(STICK_BOUNDS_SIZE * 2.)),
+                        color: EXTENT_COLOR,
                         ..default()
-                    });
+                    },));
                     // live zone
-                    parent.spawn(SpriteBundle {
-                        transform: Transform::from_xyz(live_mid, live_mid, 2.),
-                        sprite: Sprite {
+                    parent.spawn((
+                        Transform::from_xyz(live_mid, live_mid, 2.),
+                        Sprite {
                             custom_size: Some(Vec2::new(live_size, live_size)),
                             color: LIVE_COLOR,
                             ..default()
                         },
-                        ..default()
-                    });
+                    ));
                     // dead zone
-                    parent.spawn(SpriteBundle {
-                        transform: Transform::from_xyz(dead_mid, dead_mid, 3.),
-                        sprite: Sprite {
+                    parent.spawn((
+                        Transform::from_xyz(dead_mid, dead_mid, 3.),
+                        Sprite {
                             custom_size: Some(Vec2::new(dead_size, dead_size)),
                             color: DEAD_COLOR,
                             ..default()
                         },
-                        ..default()
-                    });
+                    ));
                     // text
-                    let style = TextStyle {
+                    let font = TextFont {
                         font_size: 16.,
-                        color: TEXT_COLOR,
                         font: font.clone(),
+                        ..default()
                     };
                     parent
-                        .spawn(Text2dBundle {
-                            transform: Transform::from_xyz(0., STICK_BOUNDS_SIZE + 2., 4.),
-                            text: Text::from_sections([
-                                TextSection {
-                                    value: format!("{:.3}", 0.),
-                                    style: style.clone(),
-                                },
-                                TextSection {
-                                    value: ", ".to_string(),
-                                    style: style.clone(),
-                                },
-                                TextSection {
-                                    value: format!("{:.3}", 0.),
-                                    style,
-                                },
-                            ])
-                            .with_justify(JustifyText::Center),
-                            ..default()
-                        })
-                        .insert(TextWithAxes { x_axis, y_axis });
+                        .spawn((
+                            Transform::from_xyz(0., STICK_BOUNDS_SIZE + 2., 4.),
+                            Text2d::new(""),
+                            font,
+                            stick,
+                        ))
+                        .with_child(Text2d::new(format!("{:.3}", 0.)))
+                        .with_child(Text2d::new(", ".to_string()))
+                        .with_child(Text2d::new(format!("{:.3}", 0.)));
                     // cursor
-                    parent
-                        .spawn(MaterialMesh2dBundle {
-                            mesh: meshes.circle.clone(),
-                            material: materials.normal.clone(),
-                            transform: Transform::from_xyz(0., 0., 5.)
-                                .with_scale(Vec2::splat(0.2).extend(1.)),
-                            ..default()
-                        })
-                        .insert(MoveWithAxes {
-                            x_axis,
-                            y_axis,
-                            scale: STICK_BOUNDS_SIZE,
-                        })
-                        .insert(ReactTo(button));
+                    parent.spawn((
+                        Mesh2d(meshes.circle.clone()),
+                        MeshMaterial2d(materials.normal.clone()),
+                        Transform::from_xyz(0., 0., 5.).with_scale(Vec2::splat(0.2).extend(1.)),
+                        stick,
+                        ButtonScale(STICK_BOUNDS_SIZE),
+                        ReactTo(button),
+                    ));
                 });
         };
 
         spawn_stick(
             -STICKS_X,
             STICKS_Y,
-            GamepadAxisType::LeftStickX,
-            GamepadAxisType::LeftStickY,
-            GamepadButtonType::LeftThumb,
+            GamepadStick::Left,
+            GamepadButton::LeftThumb,
         );
         spawn_stick(
             STICKS_X,
             STICKS_Y,
-            GamepadAxisType::RightStickX,
-            GamepadAxisType::RightStickY,
-            GamepadButtonType::RightThumb,
+            GamepadStick::Right,
+            GamepadButton::RightThumb,
         );
     }
 
@@ -459,77 +421,59 @@ mod gamepad_viewer_example {
     ) {
         let mut spawn_trigger = |x, y, button_type| {
             commands
-                .spawn(MaterialMesh2dBundle {
-                    mesh: meshes.trigger.clone(),
-                    material: materials.normal.clone(),
-                    transform: Transform::from_xyz(x, y, 0.),
-                    ..default()
-                })
+                .spawn((
+                    Mesh2d(meshes.trigger.clone()),
+                    MeshMaterial2d(materials.normal.clone()),
+                    Transform::from_xyz(x, y, 0.),
+                ))
                 .insert(ReactTo(button_type))
                 .with_children(|parent| {
                     parent
-                        .spawn(Text2dBundle {
-                            transform: Transform::from_xyz(0., 0., 1.),
-                            text: Text::from_section(
-                                format!("{:.3}", 0.),
-                                TextStyle {
-                                    font: font.clone(),
-                                    font_size: 16.,
-                                    color: TEXT_COLOR,
-                                },
-                            )
-                            .with_justify(JustifyText::Center),
-                            ..default()
-                        })
+                        .spawn((
+                            Transform::from_xyz(0., 0., 1.),
+                            Text2d::new(format!("{:.3}", 0.)),
+                            TextFont {
+                                font: font.clone(),
+                                font_size: 16.,
+                                ..default()
+                            },
+                            TEXT_COLOR,
+                        ))
                         .insert(TextWithButtonValue(button_type));
                 });
         };
 
-        spawn_trigger(
-            -BUTTONS_X,
-            BUTTONS_Y + 145.,
-            GamepadButtonType::LeftTrigger2,
-        );
-        spawn_trigger(
-            BUTTONS_X,
-            BUTTONS_Y + 145.,
-            GamepadButtonType::RightTrigger2,
-        );
+        spawn_trigger(-BUTTONS_X, BUTTONS_Y + 145., GamepadButton::LeftTrigger2);
+        spawn_trigger(BUTTONS_X, BUTTONS_Y + 145., GamepadButton::RightTrigger2);
     }
 
     fn setup_connected(mut commands: Commands, font: Res<FontHandle>) {
-        let style = TextStyle {
-            color: TEXT_COLOR,
+        let font = TextFont {
             font_size: 30.,
             font: font.clone(),
+            ..default()
         };
         commands
-            .spawn(TextBundle::from_sections([
-                TextSection {
-                    value: "Connected Gamepads\n".to_string(),
-                    style: style.clone(),
-                },
-                TextSection {
-                    value: "None".to_string(),
-                    style,
-                },
-            ]))
-            .insert(ConnectedGamepadsText);
+            .spawn((
+                Text2d::new("Connected Gamepads\n".to_string()),
+                font.clone(),
+            ))
+            .insert(ConnectedGamepadsText)
+            .with_child(Text2d::new("None"));
     }
 
     fn update_buttons(
-        gamepads: Res<Gamepads>,
-        button_inputs: Res<ButtonInput<GamepadButton>>,
+        gamepads: Query<&Gamepad>,
         materials: Res<ButtonMaterials>,
-        mut query: Query<(&mut Handle<ColorMaterial>, &ReactTo)>,
+        mut query: Query<(&mut MeshMaterial2d<ColorMaterial>, &ReactTo)>,
     ) {
         for gamepad in gamepads.iter() {
             for (mut handle, react_to) in query.iter_mut() {
-                if button_inputs.just_pressed(GamepadButton::new(gamepad, **react_to)) {
-                    *handle = materials.active.clone();
+                if gamepad.just_pressed(**react_to) {
+                    handle.0 = materials.active.clone();
                 }
-                if button_inputs.just_released(GamepadButton::new(gamepad, **react_to)) {
-                    *handle = materials.normal.clone();
+                if gamepad.just_released(**react_to) {
+                    handle.0 = materials.normal.clone();
                 }
             }
         }
@@ -537,18 +481,13 @@ mod gamepad_viewer_example {
 
     fn update_button_values(
         mut events: EventReader<GamepadEvent>,
-        mut query: Query<(&mut Text, &TextWithButtonValue)>,
+        mut query: Query<(&mut Text2d, &TextWithButtonValue)>,
     ) {
         for event in events.read() {
-            if let GamepadEvent::Button(GamepadButtonChangedEvent {
-                gamepad: _,
-                button_type,
-                value,
-            }) = event
-            {
+            if let GamepadEvent::Button(GamepadButtonChangedEvent { button, value, .. }) = event {
                 for (mut text, text_with_button_value) in query.iter_mut() {
-                    if *button_type == **text_with_button_value {
-                        text.sections[0].value = format!("{:.3}", value);
+                    if *button == **text_with_button_value {
+                        text.0 = format!("{:3}", value);
                     }
                 }
             }
@@ -556,43 +495,41 @@ mod gamepad_viewer_example {
     }
 
     fn update_axes(
-        mut events: EventReader<GamepadEvent>,
-        mut query: Query<(&mut Transform, &MoveWithAxes)>,
-        mut text_query: Query<(&mut Text, &TextWithAxes)>,
+        gamepads: Query<&Gamepad>,
+        mut ui_query: Query<(&mut Transform, &GamepadStick, &ButtonScale), Without<Text2d>>,
+        text_query: Query<(Entity, &GamepadStick), With<Text2d>>,
+        mut text_writer: Text2dWriter,
     ) {
-        for event in events.read() {
-            if let GamepadEvent::Axis(axis_changed_event) = event {
-                let axis_type = axis_changed_event.axis_type;
-                let value = axis_changed_event.value;
-
-                for (mut transform, move_with) in query.iter_mut() {
-                    if axis_type == move_with.x_axis {
-                        transform.translation.x = value * move_with.scale;
-                    }
-                    if axis_type == move_with.y_axis {
-                        transform.translation.y = value * move_with.scale;
-                    }
-                }
-                for (mut text, text_with_axes) in text_query.iter_mut() {
-                    if axis_type == text_with_axes.x_axis {
-                        text.sections[0].value = format!("{:.3}", value);
-                    }
-                    if axis_type == text_with_axes.y_axis {
-                        text.sections[2].value = format!("{:.3}", value);
-                    }
-                }
+        for gamepad in gamepads.iter() {
+            let left_stick = gamepad.left_stick();
+            let right_stick = gamepad.right_stick();
+            for (mut transform, stick, scale) in ui_query.iter_mut() {
+                let stick_pos = match stick {
+                    GamepadStick::Left => left_stick,
+                    GamepadStick::Right => right_stick,
+                };
+                transform.translation.x = stick_pos.x * scale.0;
+                transform.translation.y = stick_pos.y * scale.0;
+            }
+            for (text_root, stick) in text_query.iter() {
+                let stick_pos = match stick {
+                    GamepadStick::Left => left_stick,
+                    GamepadStick::Right => right_stick,
+                };
+                let index = match stick {
+                    GamepadStick::Left => 1,
+                    GamepadStick::Right => 3,
+                };
+                let mut text = text_writer.text(text_root, index);
+                *text = format!("{:3}", stick_pos.x);
             }
         }
     }
 
     fn update_connected(
-        gamepads: Res<Gamepads>,
-        mut query: Query<&mut Text, With<ConnectedGamepadsText>>,
+        gamepads: Query<&Gamepad>,
+        mut query: Query<&mut Text2d, With<ConnectedGamepadsText>>,
     ) {
-        if !gamepads.is_changed() {
-            return;
-        }
-
         let mut text = query.single_mut();
 
         let formatted = gamepads
@@ -601,7 +538,7 @@ mod gamepad_viewer_example {
             .collect::<Vec<_>>()
             .join("\n");
 
-        text.sections[1].value = if !formatted.is_empty() {
+        text.0 = if !formatted.is_empty() {
             formatted
         } else {
             "None".to_string()

--- a/examples/gamepad.rs
+++ b/examples/gamepad.rs
@@ -328,9 +328,12 @@ mod gamepad_viewer_example {
         mut commands: Commands,
         meshes: Res<ButtonMeshes>,
         materials: Res<ButtonMaterials>,
-        gamepad_settings: Single<&GamepadSettings>,
+        gamepad_settings: Query<&GamepadSettings>,
         font: Res<FontHandle>,
     ) {
+        let Some(gamepad_settings) = gamepad_settings.iter().next() else {
+            return;
+        };
         let dead_upper =
             STICK_BOUNDS_SIZE * gamepad_settings.default_axis_settings.deadzone_upperbound();
         let dead_lower =

--- a/examples/input_playback.rs
+++ b/examples/input_playback.rs
@@ -28,7 +28,7 @@ enum InputStrategy {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 }
 
 pub fn cursor_pos_as_world_pos(
@@ -38,7 +38,7 @@ pub fn cursor_pos_as_world_pos(
     let (camera_transform, camera) = camera_query.single();
     current_window
         .cursor_position()
-        .and_then(|cursor| camera.viewport_to_world(camera_transform, cursor))
+        .and_then(|cursor| camera.viewport_to_world(camera_transform, cursor).ok())
         .map(|ray| ray.origin.truncate())
 }
 
@@ -57,20 +57,18 @@ fn spawn_boxes(
         let primary_window = windows.single();
         // Don't break if we leave the window
         if let Some(cursor_pos) = cursor_pos_as_world_pos(primary_window, &camera_query) {
-            commands
-                .spawn(SpriteBundle {
-                    sprite: Sprite {
-                        color: Color::Srgba(palettes::css::DARK_GREEN),
-                        ..default()
-                    },
-                    transform: Transform {
-                        translation: cursor_pos.extend(0.0),
-                        scale: Vec3::splat(BOX_SCALE),
-                        ..default()
-                    },
+            commands.spawn((
+                Sprite {
+                    color: Color::Srgba(palettes::css::DARK_GREEN),
                     ..default()
-                })
-                .insert(Box);
+                },
+                Transform {
+                    translation: cursor_pos.extend(0.0),
+                    scale: Vec3::splat(BOX_SCALE),
+                    ..default()
+                },
+                Box,
+            ));
         }
     }
 }

--- a/src/input_capture.rs
+++ b/src/input_capture.rs
@@ -27,8 +27,8 @@ pub struct InputCapturePlugin;
 
 impl Plugin for InputCapturePlugin {
     fn build(&self, app: &mut App) {
-        app.observe(BeginInputCapture::observer)
-            .observe(EndInputCapture::observer)
+        app.add_observer(BeginInputCapture::observer)
+            .add_observer(EndInputCapture::observer)
             .add_systems(
                 Last,
                 (

--- a/src/input_playback.rs
+++ b/src/input_playback.rs
@@ -30,14 +30,14 @@ pub struct InputPlaybackPlugin;
 
 impl Plugin for InputPlaybackPlugin {
     fn build(&self, app: &mut App) {
-        app.observe(BeginInputPlayback::observer)
-            .observe(EndInputPlayback::observer)
+        app.add_observer(BeginInputPlayback::observer)
+            .add_observer(EndInputPlayback::observer)
             .add_systems(
                 First,
                 playback_timestamped_input
                     .run_if(
                         resource_exists::<PlaybackProgress>
-                            .and_then(resource_exists::<TimestampedInputs>),
+                            .and(resource_exists::<TimestampedInputs>),
                     )
                     .after(bevy::ecs::event::EventUpdates),
             );

--- a/tests/input_capture.rs
+++ b/tests/input_capture.rs
@@ -20,6 +20,7 @@ const TEST_PRESS: KeyboardInput = KeyboardInput {
     key_code: KeyCode::KeyF,
     state: ButtonState::Pressed,
     window: Entity::PLACEHOLDER,
+    repeat: false,
 };
 
 const TEST_RELEASE: KeyboardInput = KeyboardInput {
@@ -27,6 +28,7 @@ const TEST_RELEASE: KeyboardInput = KeyboardInput {
     key_code: KeyCode::KeyF,
     state: ButtonState::Released,
     window: Entity::PLACEHOLDER,
+    repeat: false,
 };
 
 const TEST_MOUSE: MouseButtonInput = MouseButtonInput {

--- a/tests/input_playback.rs
+++ b/tests/input_playback.rs
@@ -2,6 +2,7 @@
 
 use bevy::core::FrameCount;
 use bevy::ecs::event::EventRegistry;
+use bevy::ecs::event::ShouldUpdateEvents;
 use bevy::input::keyboard::Key;
 use bevy::input::keyboard::KeyboardInput;
 use bevy::input::ButtonState;
@@ -24,6 +25,7 @@ const TEST_PRESS: KeyboardInput = KeyboardInput {
     key_code: KeyCode::KeyF,
     state: ButtonState::Pressed,
     window: Entity::PLACEHOLDER,
+    repeat: false,
 };
 
 const TEST_RELEASE: KeyboardInput = KeyboardInput {
@@ -31,6 +33,7 @@ const TEST_RELEASE: KeyboardInput = KeyboardInput {
     key_code: KeyCode::KeyF,
     state: ButtonState::Released,
     window: Entity::PLACEHOLDER,
+    repeat: false,
 };
 
 fn playback_app() -> App {
@@ -77,7 +80,7 @@ fn minimal_playback() {
         source: Some(InputPlaybackSource::from_inputs(simple_timestamped_input())),
         ..Default::default()
     });
-    app.world_mut().flush_commands();
+    app.world_mut().flush();
 
     let input_events = app.world().resource::<Events<KeyboardInput>>();
     assert_eq!(input_events.len(), 0);
@@ -108,7 +111,7 @@ fn capture_and_playback() {
         source: Some(InputPlaybackSource::from_inputs(Default::default())),
         ..Default::default()
     });
-    app.world_mut().flush_commands();
+    app.world_mut().flush();
 
     let mut input_events = app.world_mut().resource_mut::<Events<KeyboardInput>>();
     input_events.send(TEST_PRESS);
@@ -147,7 +150,7 @@ fn repeated_playback() {
         source: Some(InputPlaybackSource::from_inputs(simple_timestamped_input())),
         ..Default::default()
     });
-    app.world_mut().flush_commands();
+    app.world_mut().flush();
 
     let input_events = app.world().resource::<Events<KeyboardInput>>();
     assert_eq!(input_events.len(), 0);
@@ -180,7 +183,7 @@ fn playback_strategy_paused() {
         source: Some(InputPlaybackSource::from_inputs(complex_timestamped_input())),
         ..Default::default()
     });
-    app.world_mut().flush_commands();
+    app.world_mut().flush();
 
     let timestamped_input = app.world().resource::<TimestampedInputs>();
     assert_eq!(timestamped_input.cursor, 0);
@@ -202,7 +205,7 @@ fn playback_strategy_frame() {
         source: Some(InputPlaybackSource::from_inputs(complex_timestamped_input())),
         ..Default::default()
     });
-    app.world_mut().flush_commands();
+    app.world_mut().flush();
 
     let timestamped_input = app.world().resource::<TimestampedInputs>();
     assert_eq!(timestamped_input.cursor, 0);
@@ -235,7 +238,7 @@ fn playback_strategy_frame_range_once() {
         source: Some(InputPlaybackSource::from_inputs(complex_timestamped_input())),
         ..Default::default()
     });
-    app.world_mut().flush_commands();
+    app.world_mut().flush();
 
     let timestamped_input = app.world().resource::<TimestampedInputs>();
     assert_eq!(timestamped_input.cursor, 0);
@@ -280,7 +283,7 @@ fn playback_strategy_frame_range_loop() {
         source: Some(InputPlaybackSource::from_inputs(complex_timestamped_input())),
         ..Default::default()
     });
-    app.world_mut().flush_commands();
+    app.world_mut().flush();
 
     let timestamped_input = app.world().resource::<TimestampedInputs>();
     assert_eq!(timestamped_input.cursor, 0);


### PR DESCRIPTION
# Issue

This upgrades Bevy to 0.15.

# Changes

- Included the required `bevy_window` feature in dependencies
- Renamed `App::observe` to `App::add_observer`
- Renamed `Condition(?)::and_then` to `::and`
- Added `repeat` field to keyboard inputs
- `World::flush_commnads` is now private, replaced with `World::flush`
- Updated `gamepad` example to accommodate refactors around (1) gamepads (now entities instead of tracked by resources) and (2) Text. This comprises the bulk of the meaningful changes.

Hope this helps!